### PR TITLE
Update credential types

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -23,6 +23,6 @@ controller_credential_types:
         - SN_PASSWORD
     injectors:
       env:
-        SN_HOST: "{% raw %}{{ '{{' }} SN_HOST {{ '}}' }}{% endraw %}"
-        SN_USERNAME: "{% raw %}{{ '{{' }} SN_USERNAME {{ '}}' }}{% endraw %}"
-        SN_PASSWORD: "{% raw %}{{ '{{' }} SN_PASSWORD {{ '}}' }}{% endraw %}"
+        SN_HOST: "{% raw %}{  { SN_HOST }}{% endraw %}"
+        SN_USERNAME: "{% raw %}{  { SN_USERNAME }}{% endraw %}"
+        SN_PASSWORD: "{% raw %}{  { SN_PASSWORD }}{% endraw %}"


### PR DESCRIPTION
Wanted to point out the actual workaround we have for this, is to put two spaces in between one set of curlies, the role will edit out any double spaces with a regex replace.

The issue is that ansible does not like these as variables as it thinks it is a jinja substitution. 
Details about this are here
https://github.com/redhat-cop/tower_configuration/tree/devel/roles/credential_types#formating-injectors